### PR TITLE
#include <vector>

### DIFF
--- a/scr/air.hpp
+++ b/scr/air.hpp
@@ -10,6 +10,7 @@
 #define air_hpp
 
 #include <stdio.h>
+#include <vector>
 #include "../lib/Eigen/Core"
 
 using namespace std;


### PR DESCRIPTION
Include vector library to fix compilation errors on MinGW.