### PR TITLE
Add feature to support Homebrew

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,12 @@ ifeq ($(UNAME_S),Linux)
 endif
 ifeq ($(UNAME_S),Darwin)
 	# OSX
+ifneq ($(shell which brew),)
+	# Homebrew
+	INCPATHS += $(shell brew --prefix boost)/include
+else
 	INCPATHS += /opt/local/include
+endif
 endif
 ifneq ($(filter MINGW64%, $(UNAME_S)),)
 	# MinGW64


### PR DESCRIPTION
I found an issue that it cannot be compiled with boost installed by Homebrew, so I provide this PR that will fix it.

This makes installing OpenTsiolkovsky to macOS with Homebrew simplified as follows:

```zsh
brew install boost
git clone https://github.com/istellartech/OpenTsiolkovsky.git
cd OpenTsiolkovsky
make
```